### PR TITLE
Updated - README.md

### DIFF
--- a/strings/README.md
+++ b/strings/README.md
@@ -9,7 +9,6 @@
 5. [String Tokeniser](c-or-cpp/string-tokeniser.cpp)
 
 ### C#
-You could use any online IDE (for an example [.net Finddle](https://dotnetfiddle.net/)) to test them.
 
 1. [Palindrome Check](csharp/palindrome.cs)
 


### PR DESCRIPTION
This commit removes the statement in the section c# of README.md which states "You could use any online IDE (for an example [.net Finddle](https://dotnetfiddle.net/)) to test them."