### PR TITLE
Add Python doctests to karatsuba.py

### DIFF
--- a/multiplication/python/karatsuba.py
+++ b/multiplication/python/karatsuba.py
@@ -49,7 +49,8 @@ def add(x, y):
 def absolute_difference(x, y):
   """
   >>> all(absolute_difference(str(x), str(y)) == str(abs(x - y)) for x, y
-  ...   in ((0, 0), (0, 1), (1, 1234567890), (543210, 9876543)))
+  ...   in ((0, 0), (0, 1), (1, 0), (1, 1234567890), (543210, 9876543)))
+  True
   >>> absolute_difference("1", "0")
   '1'
   """

--- a/multiplication/python/karatsuba.py
+++ b/multiplication/python/karatsuba.py
@@ -1,4 +1,13 @@
 def equalize_strings(x, y):
+  """
+  >>> def eq_str(x, y):
+  ...   max_len = max(len(x), len(y))
+  ...   return x.zfill(max_len), y.zfill(max_len), max_len
+  >>>
+  >>> all(equalize_strings(x, y) == eq_str(x, y) for x, y
+  ...   in (('x' * i, 'y' * (i // 2)) for i in range(10)))
+  True
+  """
   n = len(x)
   m = len(y)
   zeros = abs(n - m) * '0'
@@ -9,6 +18,11 @@ def equalize_strings(x, y):
   return x, y, len(x)
 
 def sum(x, y):
+  """
+  >>> all(sum(str(x), str(y)) == str(x + y) for x, y
+  ...   in ((0, 0), (0, 1), (1, 1234567890), (543210, 9876543)))
+  True
+  """
   x, y, size = equalize_strings(x, y)
   carry = 0
   result = ''
@@ -26,6 +40,14 @@ def sum(x, y):
   return result
 
 def subtract(x, y):
+  """
+  >>> subtract("0", "0")
+  '0'
+  >>> subtract("1", "0")
+  '1'
+  >>> subtract("0", "1")  # This should be -1!!
+  '1'
+  """
   x, y, size = equalize_strings(x, y)
   carry = 0
   result = ""
@@ -51,6 +73,11 @@ def subtract(x, y):
   return result
 
 def kmul(x ,y):
+  """
+  >>> all(kmul(str(x), str(y)) == str(x * y) for x, y
+  ...   in ((0, 0), (0, 1), (1, 1234567890), (543210, 9876543)))
+  True
+  """
   x, y, size = equalize_strings(x, y)
   if size == 1:
     return str(int(x) * int(y))
@@ -70,6 +97,7 @@ def kmul(x ,y):
   result = result.lstrip('0')
   return result
 
-x = "134231412"
-y = "141324"
-print(kmul(x, y))
+if __name__ == "__main__":
+  x = "134231412"
+  y = "141324"
+  print(kmul(x, y))

--- a/multiplication/python/karatsuba.py
+++ b/multiplication/python/karatsuba.py
@@ -49,7 +49,9 @@ def add(x, y):
 def absolute_difference(x, y):
   """
   >>> all(absolute_difference(str(x), str(y)) == str(abs(x - y)) for x, y
-  ...   in ((0, 0), (0, 1), (1, 0), (1, 1234567890), (543210, 9876543)))
+  ...   in ((0, 0), (0, 1), (1, 1234567890), (543210, 9876543)))
+  >>> absolute_difference("1", "0")
+  '1'
   """
   x, y, size = equalize_strings(x, y)
   carry = 0

--- a/multiplication/python/karatsuba.py
+++ b/multiplication/python/karatsuba.py
@@ -51,8 +51,6 @@ def absolute_difference(x, y):
   >>> all(absolute_difference(str(x), str(y)) == str(abs(x - y)) for x, y
   ...   in ((0, 0), (0, 1), (1, 0), (1, 1234567890), (543210, 9876543)))
   True
-  >>> absolute_difference("1", "0")
-  '1'
   """
   x, y, size = equalize_strings(x, y)
   carry = 0

--- a/multiplication/python/karatsuba.py
+++ b/multiplication/python/karatsuba.py
@@ -1,3 +1,8 @@
+"""
+https://en.wikipedia.org/wiki/Karatsuba_algorithm
+"""
+
+
 def equalize_strings(x, y):
   """
   >>> def eq_str(x, y):
@@ -17,10 +22,11 @@ def equalize_strings(x, y):
     x = zeros + x
   return x, y, len(x)
 
-def sum(x, y):
+
+def add(x, y):
   """
-  >>> all(sum(str(x), str(y)) == str(x + y) for x, y
-  ...   in ((0, 0), (0, 1), (1, 1234567890), (543210, 9876543)))
+  >>> all(add(str(x), str(y)) == str(x + y) for x, y
+  ...   in ((0, 0), (0, 1), (1, 0), (1, 1234567890), (543210, 9876543)))
   True
   """
   x, y, size = equalize_strings(x, y)
@@ -39,14 +45,11 @@ def sum(x, y):
     result = '1' + result
   return result
 
-def subtract(x, y):
+
+def absolute_difference(x, y):
   """
-  >>> subtract("0", "0")
-  '0'
-  >>> subtract("1", "0")
-  '1'
-  >>> subtract("0", "1")  # This should be -1!!
-  '1'
+  >>> all(absolute_difference(str(x), str(y)) == str(abs(x - y)) for x, y
+  ...   in ((0, 0), (0, 1), (1, 0), (1, 1234567890), (543210, 9876543)))
   """
   x, y, size = equalize_strings(x, y)
   carry = 0
@@ -72,10 +75,11 @@ def subtract(x, y):
     result = str(dgt3) + result
   return result
 
+
 def kmul(x ,y):
   """
   >>> all(kmul(str(x), str(y)) == str(x * y) for x, y
-  ...   in ((0, 0), (0, 1), (1, 1234567890), (543210, 9876543)))
+  ...   in ((0, 0), (0, 1), (1, 0), (1, 1234567890), (543210, 9876543)))
   True
   """
   x, y, size = equalize_strings(x, y)
@@ -88,14 +92,15 @@ def kmul(x ,y):
   d = y[mid:]
   ac = kmul(a, c)
   bd = kmul(b, d)
-  ab_cd = kmul(sum(a, b), sum(c, d))
-  ad_bc = subtract(ab_cd, sum(ac, bd))
+  ab_cd = kmul(add(a, b), add(c, d))
+  ad_bc = absolute_difference(ab_cd, add(ac, bd))
   zeros = "0" * (size - mid)
 
-  result = sum(ac + 2 * zeros, ad_bc + zeros)
-  result = sum(result, bd)
+  result = add(ac + 2 * zeros, ad_bc + zeros)
+  result = add(result, bd)
   result = result.lstrip('0')
   return result
+
 
 if __name__ == "__main__":
   x = "134231412"


### PR DESCRIPTION
`subtract()` can give the wrong answer when `y` > `x`.  @atin Your review, please.

Also, [`sum()`](https://docs.python.org/3/library/functions.html) is a Python built-in with a different calling convention so it would be better to use the function name `add()`.