### PR TITLE
Move codespell to a separate GitHub Action

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,8 +2,10 @@ name: codespell
 on:
   push:
     branches: [ main ]
+    paths: '**.py'
   pull_request:
     branches: [ main ]
+    paths: '**.py'
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,10 +2,8 @@ name: codespell
 on:
   push:
     branches: [ main ]
-    paths: '**.py'
   pull_request:
     branches: [ main ]
-    paths: '**.py'
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,14 @@
+name: codespell
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install codespell
+      - run: codespell --ignore-words-list="ans,nnumber,nin" --quiet-level=2  # --skip=""

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -2,8 +2,10 @@ name: lint_python
 on:
   push:
     branches: [ main ]
+    paths: '**.py'
   pull_request:
     branches: [ main ]
+    paths: '**.py'
 jobs:
   lint_python:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,15 +1,18 @@
 name: lint_python
-on: [pull_request, push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   lint_python:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
+      - run: pip install bandit black flake8 isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101 .  # B101 is assert statements
       - run: black --check . || true
-      - run: codespell --ignore-words-list="ans,nnumber,nin" --quiet-level=2  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black .
       - run: pip install -r requirements.txt || true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,4 +1,4 @@
-name: lint_python
+name: python
 on:
   push:
     branches: [ main ]
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
     paths: '**.py'
 jobs:
-  lint_python:
+  python:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Contributors get too confused when typos are raised by the `lint_python` so let's make codespell its own GitHub Action.