### PR TITLE
enh(CPlusPlus): insertion at end

### DIFF
--- a/algorithms/CPlusPlus/Linked-Lists/singly.cpp
+++ b/algorithms/CPlusPlus/Linked-Lists/singly.cpp
@@ -15,10 +15,11 @@ template <typename T>
 class SinglyLinkedList {
     private:
         Node<T>* head;
+        Node<T>* tail;
 
     public:
         SinglyLinkedList()
-            : head(nullptr){}
+            : head(nullptr),tail(nullptr){}
 
         void insertAtHead(T data) {
             Node<T> *temp = new Node<T>(data);
@@ -43,18 +44,15 @@ class SinglyLinkedList {
             // if head is not pointing to anything then simply point to new node
             if(this->head == nullptr) {
                 this->head = newNode;
+                this->tail = newNode;
                 return;
             }
 
-            // if list is not empty, then traverse to the last node using `temp`, then put the address of the new node in the temp->next
-            // and finally, make the next of newNode = NULL
-            Node<T> *temp = new Node<T>();
-            temp = head;
-            while(temp->next != NULL){
-                temp = temp->next;
-            }
-            temp->next = newNode;
+            // if list is not empty, then put the address of the new node in the tail->next
+            // and finally, make the next of newNode = NULL and tail will be pointing the the newNode as now it is in the last position.
+            tail->next = newNode;
             newNode->next= NULL;
+            tail=newNode;
         }
 
         T removeAtHead() {


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New algorithm
- [x] Optimization in previous algorithms
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Other, please describe:

**Briefly describe the changes in this PR**

I have added new optimization in insertion of node at the end. My idea was instead to traversing whole linked list to insert at end. Keep a pointer pointing to the end already. So insertion at end will take O(1) only.

<!-- For example you can add algorithm name, language used to implement it and link to online implementation of it -->

**Other information:**
<!-- Add any additional info you want here -->
I shall be highly obliged if you accept this pull request.