### PR TITLE
enh(single-link-list): added insert at the end method

### DIFF
--- a/algorithms/JavaScript/src/linked-lists/singly.js
+++ b/algorithms/JavaScript/src/linked-lists/singly.js
@@ -32,6 +32,24 @@ class SinglyLinkedList {
     return data;
   }
 
+  insertAtEnd(data){
+    const newNode = new Node(data);
+    if(!this.head){
+      this.head = newNode;
+      return this;
+    }
+
+    let currentNode = this.head;
+
+    while(currentNode.next){
+      currentNode = currentNode.next;
+    }
+
+    currentNode.next = newNode;
+
+    return this;
+  }
+
   printList() {
     // if head is null then list is empty
     if (this.head == null) {
@@ -52,4 +70,6 @@ array.insertAtHead(1);
 array.insertAtHead('xyz');
 array.insertAtHead(1.1);
 array.removeAtHead();
+array.insertAtEnd(99);
 array.printList();
+

--- a/algorithms/JavaScript/src/linked-lists/singly.js
+++ b/algorithms/JavaScript/src/linked-lists/singly.js
@@ -32,16 +32,16 @@ class SinglyLinkedList {
     return data;
   }
 
-  insertAtEnd(data){
+  insertAtEnd(data) {
     const newNode = new Node(data);
-    if(!this.head){
+    if (!this.head) {
       this.head = newNode;
       return this;
     }
 
     let currentNode = this.head;
 
-    while(currentNode.next){
+    while (currentNode.next) {
       currentNode = currentNode.next;
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New algorithm
- [ ] Optimization in previous algorithms
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [x] Other, please describe:
    The Single link list method in Javascript did not had any method to push / Insert at the end of the list. 

**Briefly describe the changes in this PR**
   Added a method to push elements at the end of the single link list in javascript.
<!-- For example you can add algorithm name, language used to implement it and link to online implementation of it -->

**Other information:**
<!-- Add any additional info you want here -->

