### PR TITLE
chore(CPlusPlus): add find words matching pattern dictionary

### DIFF
--- a/algorithms/CPlusPlus/README.md
+++ b/algorithms/CPlusPlus/README.md
@@ -159,6 +159,7 @@
 - [Trie for searching](Trie/trie_search.cpp)
 - [Trie for insert search and prefix_search](Trie/trie_insert_search_startWith.cpp)
 - [Trie for delete](Trie/trie_delete.cpp)
+- [Find Words Matching Pattern Dictionary](Trie/find_all_words_matching_pattern_in_given_dictionary.cpp)
 
 # Maths
 

--- a/algorithms/CPlusPlus/Trie/find_all_words_matching_pattern_in_given_dictionary.cpp
+++ b/algorithms/CPlusPlus/Trie/find_all_words_matching_pattern_in_given_dictionary.cpp
@@ -1,0 +1,120 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
+using namespace std;
+ 
+// Data structure to store a Trie node
+struct TrieNode
+{
+    // each node stores a map to its child nodes
+    unordered_map<char, TrieNode*> map;
+ 
+    // true when the node is a leaf node
+    bool isLeaf = false;
+ 
+    // collection to store a complete list of words in the leaf node
+    unordered_set<string> word;
+};
+ 
+// Function to insert a string into a Trie
+void insert(TrieNode*& head, string word)
+{
+    if (head == nullptr) {
+        head = new TrieNode();
+    }
+ 
+    // start from the head node
+    TrieNode* curr = head;
+    for (char c: word)
+    {
+        // insert only uppercase characters
+        if (isupper(c))
+        {
+            // create a new node if the path doesn't exist
+            if (curr->map.find(c) == curr->map.end()) {
+                curr->map[c] = new TrieNode();
+            }
+ 
+            // go to the next node
+            curr = curr->map[c];
+        }
+    }
+ 
+    // mark the current node as a leaf
+    curr->isLeaf = true;
+ 
+    // push the current word into the set associated with a leaf node
+    (curr->word).insert(word);
+}
+ 
+// Function to print all children of a given Trie node
+void printAllWords(TrieNode* root)
+{
+    // if the current node is a leaf, print all words associated with it
+    if (root->isLeaf)
+    {
+        unordered_set<string> collection = root->word;
+        for (string s: collection) {
+            cout << s << endl;
+        }
+    }
+ 
+    // recur for all children of the root node
+    for (auto pair: root->map)
+    {
+        TrieNode* child = pair.second;
+        if (child) {
+            printAllWords(child);
+        }
+    }
+}
+ 
+// Function to print all words in the CamelCase dictionary, which
+// matches the given pattern
+void findAllWords(vector<string> const &dictionary, string pattern)
+{
+    // base case
+    if (dictionary.size() == 0) {
+        return;
+    }
+ 
+    // Trie head node
+    TrieNode* head = nullptr;
+ 
+    // construct a Trie from the given dictionary
+    for (string s: dictionary) {
+        insert(head, s);
+    }
+ 
+    // search for the given pattern in the Trie
+    TrieNode* curr = head;
+    for (char c: pattern)
+    {
+        // move to the child node
+        curr = curr->map[c];
+ 
+        // if the given pattern is not found (reached end of a path in the Trie)
+        if (curr == nullptr) {
+            return;
+        }
+    }
+ 
+    // print all words matching the given pattern
+    printAllWords(curr);
+}
+ 
+int main()
+{
+    vector<string> dictionary {
+        "Hi", "HiTech", "HiTechCity", "Techie", "TechieDelight",
+        "Hello", "HelloWorld", "HiTechLab"
+    };
+ 
+    string pattern = "HT";
+ 
+    findAllWords(dictionary, pattern);
+ 
+    return 0;
+}


### PR DESCRIPTION
Given a dictionary of words where each word follows a CamelCase notation, find all words in it that matches a given pattern of all uppercase characters.

CamelCase Notation is the practice of writing compound words or phrases joined without spaces, where each word’s first letter is capitalized. For example, PowerPoint, LibreOffice, CinemaScope, etc., are in CamelCase.

We can use a Trie data structure to solve this problem. The idea is to insert all uppercase characters of each word in the CamelCase dictionary into a Trie. In contrast, the complete word is stored in a container associated with the corresponding leaf node. After the complete dictionary is processed, traverse the Trie and find all words that match the given pattern.

Output:
HiTech
HiTechLab
HiTechCity


<!-- To ensure your PR is dealt with swiftly please check the following: -->
**PR Checklist:**
- [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/MakeContributions/DSA#contribution-guidelines)
- [x] My addition is on refer on the language README.md file
- [x] My addition does not have a spelling problem
- [x] My submission has a proper and user-friendly description of the algorithm
- [ ] My submission has the time complexity of the algorithm
- [x] My submission has sample input-output of the program (NOT FOR PYTHON)

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] New algorithm
- [ ] Optimization in previous algorithms
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Other, please describe:

**Briefly describe the changes in this PR**

<!-- For example you can add algorithm name, language used to implement it and link to online implementation of it -->

**Other information:**
<!-- Add any additional info you want here -->
